### PR TITLE
cm: Enable long-press on power in suspend by default

### DIFF
--- a/overlay/common/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/common/frameworks/base/core/res/res/values/config.xml
@@ -71,4 +71,8 @@
          correctly use them when installed on your device.  Otherwise, keep this disabled
          so that applications can still use their own mechanisms. -->
     <bool name="config_enableAutoPowerModes">true</bool>
+
+    <!-- If this is true, long press on power button will be available from a
+         non-interactive state. -->
+    <bool name="config_supportLongPressPowerWhenNonInteractive">true</bool>
 </resources>


### PR DESCRIPTION
As of fw/b change I14365389990eb06daaa127f5db66df45abf6c064,
we now have an option to long-press on power to enable torch.

To support this feature, we need to enable long-press on power
while the device is still non-interactive.

Change-Id: I4e2b4af86d397f68e119963054c33fd890c77cc5